### PR TITLE
Equivalent dotfiles, but using compton's successor picom.

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,0 +1,2 @@
+picom -b --experimental-backends
+exec i3

--- a/i3/config
+++ b/i3/config
@@ -19,7 +19,7 @@ gaps inner 30
 # autostart
 exec --no-startup-id hsetroot -full ~/wall.png
 exec --no-startup-id xsettingsd &
-exec --no-startup-id compton -b
+#exec --no-startup-id picom -b --experimental-backends # This now gets called in .xinitrc, because I could not get it to work here.
 exec setxkbmap -layout us,ru
 exec setxkbmap -option 'grp:alt_shift_toggle'
 

--- a/picom.conf
+++ b/picom.conf
@@ -1,8 +1,7 @@
 ## Shadow
 shadow = true;
-no-dnd-shadow = true;
-no-dock-shadow = false;
-clear-shadow = true;
+shadow-dnd = true;
+shadow-dock = false;
 shadow-radius = 12;
 shadow-offset-x = -17;
 shadow-offset-y = -7;
@@ -28,9 +27,8 @@ mark-ovredir-focused = true;
 detect-rounded-corners = true;
 detect-client-opacity = true;
 refresh-rate = 0;
-vsync = "none";
+vsync = false;
 dbe = false;
-paint-on-overlay = true;
 focus-exclude = [ "class_g = 'Cairo-clock'" ,
 	"class_g = 'CoverGloobus'",
 	"class_g = 'Tilda'",
@@ -41,7 +39,7 @@ detect-transient = true;
 detect-client-leader = true;
 invert-color-include = [ ];
 glx-copy-from-front = false;
-glx-swap-method = "undefined";
+use-damage = true;
 wintypes:
 {
   tooltip = { fade = true; shadow = true; opacity = 0.75; focus = true; };
@@ -52,6 +50,7 @@ blur-background = true;
 blur-background-frame = false;
 blur-background-fixed = false;
 blur-kern = "3x3box";
-blur-method = "kawase";
+blur-method = "dual_kawase";
 blur-strength = 10;
 blur-background-exclude = [ "window_type = 'dock'", "window_type = 'desktop'" ];
+


### PR DESCRIPTION
Equivalent dotfiles compatible with compton's successor picom. Once again, tryone's fork is required for blur support.

I could not get compton to install on arch, and since it's now abandoned, I figured you will want to switch to picom sooner or later.

I was not sure how to execute this compositor from within i3config, but I managed to get it to work from within .xinitrc, hence I modified i3config and added a .xinitrc containing only the extra two lines required to run this setup.